### PR TITLE
refactor: Use multi-value in hello-world

### DIFF
--- a/exercises/practice/hello-world/.meta/proof.ci.wat
+++ b/exercises/practice/hello-world/.meta/proof.ci.wat
@@ -1,11 +1,9 @@
 (module
   (import "env" "linearMemory" (memory 1))
 
-  ;; This is a C-style string. The \00 character is a "null terminator" that
-  ;; indicates the end of the string. Be sure not to delete it!
-  (data (i32.const 200) "Hello, World!\00")
+  (data (i32.const 64) "Hello, World!")
   
-  (func (export "hello") (result i32)
-    (i32.const 200)
+  (func (export "hello") (result i32 i32)
+    (i32.const 64) (i32.const 13)
   )
 )

--- a/exercises/practice/hello-world/hello-world.spec.js
+++ b/exercises/practice/hello-world/hello-world.spec.js
@@ -34,11 +34,10 @@ describe('Hello World', () => {
 
   test('Say Hi!', () => {
     expect(currentInstance).toBeTruthy();
-    const offset = currentInstance.exports.hello();
-    const maxBuffer = 20;
-    const buffer = new Uint8Array(linearMemory.buffer, offset, maxBuffer);
-    const greetingBuffer = textDecoder.decode(buffer);
-    const greeting = greetingBuffer.split("\0")[0];
+    const [offset, length] = currentInstance.exports.hello();
+    expect(length).toBe(13);
+    const buffer = new Uint8Array(linearMemory.buffer, offset, length);
+    const greeting = textDecoder.decode(buffer);
     expect(greeting).toBe("Hello, World!");
   });
 });

--- a/exercises/practice/hello-world/hello-world.wat
+++ b/exercises/practice/hello-world/hello-world.wat
@@ -1,11 +1,11 @@
 (module
   (import "env" "linearMemory" (memory 1))
 
-  ;; This is a C-style string. The \00 character is a "null terminator" that
-  ;; indicates the end of the string. Be sure not to delete it!
-  (data (i32.const 200) "Goodbye, Mars!\00")
+  ;; Initializes the WebAssembly Linear Memory with a UTF-8 string of 14 characters starting at offset 64
+  (data (i32.const 64) "Goodbye, Mars!")
   
-  (func (export "hello") (result i32)
-    (i32.const 200)
+  ;; Returns the base offset and length of the greeting
+  (func (export "hello") (result i32 i32)
+    (i32.const 64) (i32.const 14)
   )
 )


### PR DESCRIPTION
Node 16 provides support for WebAssembly multi-value. This allows a function to return a N-way tuple. The JS API binds to this as an array of values.

This PR refactors the hello-world exercise to replace the C-style string with a "fat pointer" that returns the string length to the caller. I consider this a better approach that aligns with how WebAssembly will eventually handle "interface types" that will allow higher-level types like strings.