### PR TITLE
refactor: grains test cleanup

### DIFF
--- a/exercises/practice/grains/.meta/proof.ci.wat
+++ b/exercises/practice/grains/.meta/proof.ci.wat
@@ -1,39 +1,30 @@
 (module
+  (global $squareCount i32 (i32.const 64))
+  
   ;; Result is unsigned
-  (func $sqaure (export "square") (param $squareNum i64) (result i64)
-    (if (i32.or 
-      (i64.lt_s (local.get $squareNum) (i64.const 1)) 
-      (i64.gt_s (local.get $squareNum) (i64.const 64))
-    ) (then
-      (return (i64.const 0))
-    ))
-
-    (i64.shl (i64.const 1) (i64.sub (local.get $squareNum) (i64.const 1)))
+  (func $square (export "square") (param $squareNum i32) (result i64)
+    (if (i32.or
+        (i32.lt_s (local.get $squareNum) (i32.const 1))
+        (i32.gt_s (local.get $squareNum) (global.get $squareCount))
+      ) (then (return (i64.const 0)))
+    )
+  
+    (i64.shl (i64.const 1) (i64.extend_i32_u (i32.sub (local.get $squareNum) (i32.const 1))))
   )
 
   ;; Result is unsigned
   (func (export "total") (result i64)
+    (local $i i32)
     (local $sum i64)
-    (local $squareNum i64)
-    (local $squareVal i64)
+    
+    (local.set $i (i32.const 1))
     (local.set $sum (i64.const 0))
 
-    (if (i64.le_u (local.tee $squareNum (i64.const 1)) (i64.const 64)) (then
-      (loop
-        
-        (if (i64.eq (local.tee $squareVal (call $sqaure (local.get $squareNum))) (i64.const 0)) (then
-          (return (i64.const 0))
-        ))
-
-        (local.set $sum (i64.add (local.get $sum) (local.get $squareVal)))
-
-        (br_if 0 (i64.le_u 
-          (local.tee $squareNum (i64.add (local.get $squareNum) (i64.const 1))) 
-          (i64.const 64)
-        ))
-      )
-    ))
-
+    (loop
+      (local.set $sum (i64.add (local.get $sum) (call $square (local.get $i))))
+      (br_if 0 (i32.le_s (local.tee $i (i32.add (local.get $i) (i32.const 1))) (global.get $squareCount)))
+    )
+    
     (local.get $sum)
   )
 )

--- a/exercises/practice/grains/.meta/proof.ci.wat
+++ b/exercises/practice/grains/.meta/proof.ci.wat
@@ -1,6 +1,7 @@
 (module
   (global $squareCount i32 (i32.const 64))
   
+  ;; squareNum is signed
   ;; Result is unsigned
   (func $square (export "square") (param $squareNum i32) (result i64)
     (if (i32.or

--- a/exercises/practice/grains/grains.spec.js
+++ b/exercises/practice/grains/grains.spec.js
@@ -36,62 +36,62 @@ describe("Grains", () => {
       expect(resultUnsigned).toEqual(1n);
     });
 
-    test("grains on square 2", () => {
+    xtest("grains on square 2", () => {
       let resultSigned = currentInstance.exports.square(2);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(2n);
     });
 
-    test("grains on square 3", () => {
+    xtest("grains on square 3", () => {
       let resultSigned = currentInstance.exports.square(3);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(4n);
     });
 
-    test("grains on square 4", () => {
+    xtest("grains on square 4", () => {
       let resultSigned = currentInstance.exports.square(4);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(8n);
     });
 
-    test("grains on square 16", () => {
+    xtest("grains on square 16", () => {
       let resultSigned = currentInstance.exports.square(16);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(32768n);
     });
 
-    test("grains on square 32", () => {
+    xtest("grains on square 32", () => {
       let resultSigned = currentInstance.exports.square(32);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(2147483648n);
     });
 
-    test("grains on square 64", () => {
+    xtest("grains on square 64", () => {
       let resultSigned = currentInstance.exports.square(64);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(9223372036854775808n);
     });
 
-    test("square 0 has no value", () => {
+    xtest("square 0 has no value", () => {
       let resultSigned = currentInstance.exports.square(0);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(0n);
     });
 
-    test("negative square has no value", () => {
+    xtest("negative square has no value", () => {
       let resultSigned = currentInstance.exports.square(-1);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(0n);
     });
 
-    test("square greater than 64 has no value", () => {
+    xtest("square greater than 64 has no value", () => {
       let resultSigned = currentInstance.exports.square(65);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(0n);
     });
   });
 
-  test("returns the total number of grains on the board", () => {
+  xtest("returns the total number of grains on the board", () => {
     let resultSigned = currentInstance.exports.total();
     let resultUnsigned = BigInt.asUintN(64, resultSigned);
     expect(resultUnsigned).toEqual(18446744073709551615n);

--- a/exercises/practice/grains/grains.spec.js
+++ b/exercises/practice/grains/grains.spec.js
@@ -31,67 +31,67 @@ describe("Grains", () => {
 
   describe("returns the number of grains on the square", () => {
     test("grains on square 1", () => {
-      let resultSigned = currentInstance.exports.square(1n);
+      let resultSigned = currentInstance.exports.square(1);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(1n);
     });
 
-    xtest("grains on square 2", () => {
-      let resultSigned = currentInstance.exports.square(2n);
+    test("grains on square 2", () => {
+      let resultSigned = currentInstance.exports.square(2);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(2n);
     });
 
-    xtest("grains on square 3", () => {
-      let resultSigned = currentInstance.exports.square(3n);
+    test("grains on square 3", () => {
+      let resultSigned = currentInstance.exports.square(3);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(4n);
     });
 
-    xtest("grains on square 4", () => {
-      let resultSigned = currentInstance.exports.square(4n);
+    test("grains on square 4", () => {
+      let resultSigned = currentInstance.exports.square(4);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(8n);
     });
 
-    xtest("grains on square 16", () => {
-      let resultSigned = currentInstance.exports.square(16n);
+    test("grains on square 16", () => {
+      let resultSigned = currentInstance.exports.square(16);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(32768n);
     });
 
-    xtest("grains on square 32", () => {
-      let resultSigned = currentInstance.exports.square(32n);
+    test("grains on square 32", () => {
+      let resultSigned = currentInstance.exports.square(32);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(2147483648n);
     });
 
-    xtest("grains on square 64", () => {
-      let resultSigned = currentInstance.exports.square(64n);
+    test("grains on square 64", () => {
+      let resultSigned = currentInstance.exports.square(64);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(9223372036854775808n);
     });
 
-    xtest("square 0 has no value", () => {
-      let resultSigned = currentInstance.exports.square(0n);
+    test("square 0 has no value", () => {
+      let resultSigned = currentInstance.exports.square(0);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(0n);
     });
 
-    xtest("negative square has no value", () => {
-      let resultSigned = currentInstance.exports.square(-1n);
+    test("negative square has no value", () => {
+      let resultSigned = currentInstance.exports.square(-1);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(0n);
     });
 
-    xtest("square greater than 64 has no value", () => {
-      let resultSigned = currentInstance.exports.square(65n);
+    test("square greater than 64 has no value", () => {
+      let resultSigned = currentInstance.exports.square(65);
       let resultUnsigned = BigInt.asUintN(64, resultSigned);
       expect(resultUnsigned).toEqual(0n);
     });
   });
 
-  xtest("returns the total number of grains on the board", () => {
+  test("returns the total number of grains on the board", () => {
     let resultSigned = currentInstance.exports.total();
     let resultUnsigned = BigInt.asUintN(64, resultSigned);
     expect(resultUnsigned).toEqual(18446744073709551615n);

--- a/exercises/practice/grains/grains.wat
+++ b/exercises/practice/grains/grains.wat
@@ -1,6 +1,7 @@
 (module
+  ;; squareNum is signed
   ;; Result is unsigned
-  (func $sqaure (export "square") (param $squareNum i64) (result i64)
+  (func $square (export "square") (param $squareNum i32) (result i64)
     (i64.const 42)
   )
 


### PR DESCRIPTION
Resolves #38 

I also changed the parameter `$squareNum` from an i64 to an i32 since it only has to express 1..64.