### PR TITLE
fix: bank-account delete unused parameter

### DIFF
--- a/exercises/practice/bank-account/.meta/proof.ci.wat
+++ b/exercises/practice/bank-account/.meta/proof.ci.wat
@@ -43,7 +43,7 @@
   )
 
   ;; returns balance on success, -1 if account closed
-  (func (export "balance") (param $amount i32) (result i32)
+  (func (export "balance") (result i32)
     (if (i32.eqz (global.get $open)) (then (return (i32.const -1))))
 
     (global.get $balance)

--- a/exercises/practice/bank-account/bank-account.wat
+++ b/exercises/practice/bank-account/bank-account.wat
@@ -20,7 +20,7 @@
   )
 
   ;; returns balance on success, -1 if account closed
-  (func (export "balance") (param $amount i32) (result i32)
+  (func (export "balance") (result i32)
     (i32.const 42)
   )
 )


### PR DESCRIPTION
I likely copied code and ended up with an unused parameter on the balance function. This PR removes this!