### PR TITLE
docs: Remove redundant debugging instructions

### DIFF
--- a/exercises/practice/acronym/.docs/instructions.append.md
+++ b/exercises/practice/acronym/.docs/instructions.append.md
@@ -16,29 +16,3 @@ WebAssembly lacks the sort of string library typically found in higher level lan
 We encode characters in UTF-8 and limit input to ASCII character encoding.
 
 Reference: https://en.wikipedia.org/wiki/ASCII
-
-## Relevant Debugging Imports
-
-### Log a string from linear memory
-
-```wasm
-(import "console" "log_mem_as_utf8" (func $log_mem_as_utf8 (param $byteOffset i32) (param $length i32)))
-```
-
-And then log as follows:
-
-```wasm
-(call $log_mem_as_utf8 (i32.const 64) (i32.const i28))
-```
-
-### Log an variable containing an integer
-
-```wasm
-(import "console" "log_i32_s" (func $log_i32_s (param i32)))
-```
-
-And then log as follows:
-
-```wasm
-(call $log_i32_s (local.get $i))
-```

--- a/exercises/practice/all-your-base/.docs/instructions.append.md
+++ b/exercises/practice/all-your-base/.docs/instructions.append.md
@@ -1,17 +1,3 @@
 ## Reserved Addresses
 
 All input is provided as parameters, so no addresses in the linear memory are reserved.
-
-## Relevant Debugging Imports
-
-### Log an variable containing an integer
-
-```wasm
-(import "console" "log_i32_s" (func $log_i32_s (param i32)))
-```
-
-And then log as follows:
-
-```wasm
-(call $log_i32_s (local.get $i))
-```

--- a/exercises/practice/armstrong-numbers/.docs/instructions.append.md
+++ b/exercises/practice/armstrong-numbers/.docs/instructions.append.md
@@ -1,17 +1,3 @@
 ## Reserved Addresses
 
 No linear memory is requires for this exercise.
-
-## Relevant Debugging Imports
-
-### Log an variable containing an integer
-
-```wasm
-(import "console" "log_i32_s" (func $log_i32_s (param i32)))
-```
-
-And then log as follows:
-
-```wasm
-(call $log_i32_s (local.get $i))
-```

--- a/exercises/practice/hamming/.docs/instructions.append.md
+++ b/exercises/practice/hamming/.docs/instructions.append.md
@@ -17,29 +17,3 @@ WebAssembly lacks the sort of string library typically found in higher level lan
 We encode characters in UTF-8 and limit input to ASCII character encoding.
 
 Reference: https://en.wikipedia.org/wiki/ASCII
-
-## Relevant Debugging Imports
-
-### Log a string from linear memory
-
-```wasm
-(import "console" "log_mem_as_utf8" (func $log_mem_as_utf8 (param $byteOffset i32) (param $length i32)))
-```
-
-And then log as follows:
-
-```wasm
-(call $log_mem_as_utf8 (i32.const 64) (i32.const i28))
-```
-
-### Log an variable containing an integer
-
-```wasm
-(import "console" "log_i32_s" (func $log_i32_s (param i32)))
-```
-
-And then log as follows:
-
-```wasm
-(call $log_i32_s (local.get $i))
-```


### PR DESCRIPTION
The documentation in shared/.docs/debug.md gets automatically appended to the instructions in the Web UI, so this information is redundant.