### PR TITLE
chore: Add missing config for docs

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "9e321dda-b0e7-4d45-bee0-8fcc5d393277",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing WebAssembly locally",
+      "blurb": "Learn how to install WebAssembly locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "79e94319-d3a6-4a61-8471-bfdde20cdc72",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn WebAssembly",
+      "blurb": "An overview of how to get started from scratch with WebAssembly"
+    },
+    {
+      "uuid": "8589c25b-e12a-4108-bae3-5e5a3b6e3c01",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the WebAssembly track",
+      "blurb": "Learn how to test your WebAssembly exercises on Exercism"
+    },
+    {
+      "uuid": "9ed0de19-97cd-4a50-b27f-5965c32b2c3f",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful WebAssembly resources",
+      "blurb": "A collection of useful resources to help you master WebAssembly"
+    }
+  ]
+}


### PR DESCRIPTION
It seems that the track documentation wasn't rendering due to a missing config. I've added this below.