### PR TITLE
fix: reverse-string pass size in bytes

### DIFF
--- a/exercises/practice/reverse-string/reverse-string.spec.js
+++ b/exercises/practice/reverse-string/reverse-string.spec.js
@@ -30,7 +30,7 @@ function reverseString(input) {
   // Pass offset and length to WebAssembly function
   const [outputOffset, outputLength] = currentInstance.exports.reverseString(
     inputBufferOffset,
-    input.length
+    inputLengthEncoded
   );
   expect(outputLength).toEqual(inputLengthEncoded);
 


### PR DESCRIPTION
Hello! I was trying to support all UTF-8 characters in my solution and stumbled upon this.
It feels right to fix this: I would expect output length to be equal to the input one!

It doesn't matter at all for ASCII strings, but if people want to support non-ASCII strings in their solution, this makes new tests just work.