### PR TITLE
[Hello World]:  Added comment to stub and Instruction Append

### DIFF
--- a/exercises/practice/hello-world/.meta/instructions.append.md
+++ b/exercises/practice/hello-world/.meta/instructions.append.md
@@ -2,6 +2,6 @@
 
 ~~~~exercism/caution
 
-Unlike most “Hello World” exercises on Exercism, Web Assembly requires an extra change to the code you are provided with in the start file. As well as changing the string itself, you must also change the **length of the greeting** in the function definition. See the comment in the starter code for more details.
+Unlike most “Hello World” exercises on Exercism, WebAssembly requires an extra change to the code you are provided with in the start file. As well as changing the string itself, you must also change the **length of the greeting** in the function definition. See the comment in the starter code for more details.
 
 ~~~~

--- a/exercises/practice/hello-world/.meta/instructions.append.md
+++ b/exercises/practice/hello-world/.meta/instructions.append.md
@@ -1,0 +1,7 @@
+# Instructions append
+
+~~~~exercism/caution
+
+Unlike most “Hello World” exercises on Exercism, Web Assembly requires an extra change to the code you are provided with in the start file. As well as changing the string itself, you must also change the **length of the greeting** in the function definition. See the comment in the starter code for more details.
+
+~~~~

--- a/exercises/practice/hello-world/.meta/instructions.append.md
+++ b/exercises/practice/hello-world/.meta/instructions.append.md
@@ -2,6 +2,8 @@
 
 ~~~~exercism/caution
 
-Unlike most “Hello World” exercises on Exercism, WebAssembly requires an extra change to the code you are provided with in the start file. As well as changing the string itself, you must also change the **length of the greeting** in the function definition. See the comment in the starter code for more details.
+Unlike most “Hello World” exercises on Exercism, WebAssembly requires an extra change to the code you are provided with in the start file.
+As well as changing the string itself, you must also change the **length of the greeting** in the function definition.
+See the comment in the starter code for more details.
 
 ~~~~

--- a/exercises/practice/hello-world/hello-world.wat
+++ b/exercises/practice/hello-world/hello-world.wat
@@ -5,6 +5,7 @@
   (data (i32.const 64) "Goodbye, Mars!")
   
   ;; Returns the base offset and length of the greeting
+  ;; The final number (currently “14”) must match the length of the new string.
   (func (export "hello") (result i32 i32)
     (i32.const 64) (i32.const 14)
   )


### PR DESCRIPTION
Please see this [forum discussion](https://forum.exercism.org/t/hello-world-possible-issue-with-stub-code/7961) for details.

Added a comment to warn students that they need to adjust the export line in the stub file:

```webassembly
  (func (export "hello") (result i32 i32)
    (i32.const 64) (i32.const 14)
  )
```

_"Goodby, Mars!"_ is `14`, but _"Hello, World!"_ is `13`, so if `(i32.const 14)` is not changed, the student won't pass the tests.

Also added a `caution` level instruction append to alert students.

Conversely, the stub can be altered so that it is already `13` -- but then it won't match "Goodby, Mars!".