### PR TITLE
docs: Clarify linear memory use in all-your-base

### DIFF
--- a/exercises/practice/all-your-base/.docs/instructions.append.md
+++ b/exercises/practice/all-your-base/.docs/instructions.append.md
@@ -1,5 +1,31 @@
 # Instruction append
 
-## Reserved Addresses
+## WebAssembly-specific Notes
 
-All input is provided as parameters, so no addresses in the linear memory are reserved.
+The function signature for the WebAssembly export `convert` is as follows:
+
+```wasm
+(func (export "convert")
+    (param $arrOffset i32)
+    (param $arrLength i32)
+    (param $inputBase i32)
+    (param $outputBase i32)
+    (result i32 i32 i32)
+)
+```
+
+The first two parameters `$arrOffset` and `$arrLength` express the base offset and length of an array of 32-bit signed integers. The length parameter is sized in number of elements in the array, not bytes. Prior to calling this function, the caller writes this array into the WebAssembly linear memory beginning at offset `$arrOffset`. WebAssembly linear memory is always expressed in little-endian. 
+
+Thus the caller would thus encoded the array `[1,2]` as the following eight byte sequence.
+
+```
+| 64 | 65 | 66 | 67 | 68 | 69 | 70 | 71 |
+| ---- arr[0] ----- | ---- arr[1] ----- |
+,0x01,0x00,0x00,0x00,0x02,0x00,0x00,0x00,
+```
+
+The parameters `$inputBase` and `$outputBase` do not involve linear memory.
+
+The result type is `(i32 i32 i32)`. The first two values are the `offset` and `length` of your output in linear memory. If you so choose, you may overwrite the addresses of linear memory used for the input. The third return value is an i32 status code used for error handling.
+
+If the third return value expresses an error state, the unit tests do not read the first two return values.

--- a/exercises/practice/all-your-base/all-your-base.wat
+++ b/exercises/practice/all-your-base/all-your-base.wat
@@ -7,7 +7,16 @@
   (global $wrongInputBase i32 (i32.const -2))
   (global $wrongOutputBase i32 (i32.const -3))
 
-  ;; Returns offset and length of resulting u32[] and a return status code
+  ;;
+  ;; Convert an array of digits in inputBase to an array of digits in outputBase
+  ;; @param {i32} arrOffset - base offset of input u32[] array                
+  ;; @param {i32} arrLength - length of the input u32[] array in elements
+  ;; @param {i32} inputBase - base of the input array
+  ;; @param {i32} outputBase - base of the output array
+  ;; @return {i32} - base offset of the output u32[] array
+  ;; @return {i32} - length of the output u32[] array in elements                   
+  ;; @return {i32} - status code (0, -1, -2, -3)                                
+  ;;
   (func (export "convert") (param $arrOffset i32) (param $arrLength i32) (param $inputBase i32) (param $outputBase i32) (result i32 i32 i32)
     (return (local.get $arrOffset) (local.get $arrLength) (i32.const 42))
   )


### PR DESCRIPTION
Documentation-only change motivated by https://forum.exercism.org/t/regarding-the-input-to-all-your-base/8164.