### PR TITLE
fix: Validate Circular Buffer Capacity

### DIFF
--- a/exercises/practice/circular-buffer/.meta/proof.ci.wat
+++ b/exercises/practice/circular-buffer/.meta/proof.ci.wat
@@ -5,13 +5,17 @@
   (global $capacity (mut i32) (i32.const 0))
   (global $i32Size i32 (i32.const 4))
 
-
-  ;; capacity: the number of elements to store
-  ;; elementSize: the size of the element to store in bytes
-  ;; Does not support resizing circular buffer. Wipes all data
+  ;;
+  ;; Initialize a circular buffer of i32s with a given capacity
+  ;;
+  ;; @param {i32} newCapacity - capacity of the circular buffer between 0 and 16,384
+  ;;                            in order to fit in a single 64KiB WebAssembly page
+  ;;
+  ;; @returns {i32} 0 on success or -1 on error
+  ;; 
   (func (export "init") (param $newCapacity i32) (result i32)
     ;; a WebAssembly page is 4096 bytes, so up to 1024 i32s
-    (if (i32.gt_s (local.get $newCapacity) (i32.const 1024)) (then
+    (if (i32.gt_s (local.get $newCapacity) (i32.const 16384)) (then
       (return (i32.const -1))
     ))
 
@@ -21,11 +25,21 @@
     (i32.const 0)
   )
 
+  ;;
+  ;; Clear the circular buffer
+  ;;
   (func (export "clear")
     (global.set $head (i32.const -1))
     (global.set $tail (i32.const -1))
   )
 
+  ;; 
+  ;; Add an element to the circular buffer
+  ;;
+  ;; @param {i32} elem - element to add to the circular buffer
+  ;;
+  ;; @returns {i32} 0 on success or -1 if full
+  ;;
   (func (export "write") (param $elem i32) (result i32)
     (local $temp i32)
     ;; Table has capacity of zero
@@ -52,6 +66,14 @@
     (i32.const 0)
   )
 
+  ;; 
+  ;; Add an element to the circular buffer, overwriting the oldest element
+  ;; if the buffer is full
+  ;;
+  ;; @param {i32} elem - element to add to the circular buffer
+  ;;
+  ;; @returns {i32} 0 on success or -1 if full (capacity of zero)
+  ;;
   (func (export "forceWrite") (param $elem i32) (result i32)
     (local $temp i32)
     ;; Table has capacity of zero
@@ -78,7 +100,12 @@
     (i32.const 0)
   )
 
-  ;; Go-style error handling type (i32,i32)
+  ;;
+  ;; Read the oldest element from the circular buffer, if not empty
+  ;;
+  ;; @returns {i32} element on success or -1 if empty
+  ;; @returns {i32} status code set to 0 on success or -1 if empty
+  ;;
   (func (export "read") (result i32 i32)
     (local $result i32)
 

--- a/exercises/practice/circular-buffer/circular-buffer.spec.js
+++ b/exercises/practice/circular-buffer/circular-buffer.spec.js
@@ -143,4 +143,15 @@ describe("CircularBuffer", () => {
     expect(currentInstance.exports.read()).toEqual([4, 0]);
     expect(currentInstance.exports.read()).toEqual([-1, -1]);
   });
+
+  xtest("Should be able to grow up to a full 64KiB page", () => {
+    expect(currentInstance.exports.init(16384)).toEqual(0);
+    for (let i = 0; i < 16384; i++) {
+      expect(currentInstance.exports.write(1024)).toEqual(0);
+    }
+  });
+
+  xtest("init should fail if greater than full 64KiB page", () => {
+    expect(currentInstance.exports.init(16385)).toEqual(-1);
+  });
 });

--- a/exercises/practice/circular-buffer/circular-buffer.wat
+++ b/exercises/practice/circular-buffer/circular-buffer.wat
@@ -1,12 +1,13 @@
 (module
-  (memory 1)
+  ;; Cap the memory at a single 64KiB page
+  (memory 1 1)
   ;; Add globals here!
 
   ;;
   ;; Initialize a circular buffer of i32s with a given capacity
   ;;
-  ;; @param {i32} newCapacity - capacity of the circular buffer between 0 and 1024
-  ;;                            in order to fit in a single WebAssembly page
+  ;; @param {i32} newCapacity - capacity of the circular buffer between 0 and 16,384
+  ;;                            in order to fit in a single 64KiB WebAssembly page
   ;;
   ;; @returns {i32} 0 on success or -1 on error
   ;; 


### PR DESCRIPTION
`glennj` discovered a few errors in the circular buffer exercise while working through the track. This PR addresses all three.

This does add new tests and potentially break existing solutions. I would appreciate guidance on how best to merge this. I will be away from computers tomorrow during US Thanksgiving, so please feel free to merge on my behalf.

Error 1: The (memory 1) initializes the linear memory with 1 64KiB page, but it does not provide a maximum cap on what it can grow to. This means the linear memory can grow up to a full 32-bit address space. In C terms, that means you can store up to UINT32_MAX / sizeof(uint32_t) elements before filling up. I believe my intent here was that the memory instruction should be (memory 1 1), meaning "initialized with 1 64KiB page and do not allow it to grow beyond."

Error 2: The comment "capacity of the circular buffer between 0 and 1024 in order to fit in a single WebAssembly page" is wrong because wasm pages are 64Kib, not 4KiB. It should read "capacity of the circular buffer between 0 and 16,384 in order to fit in a single 64KiB WebAssembly page"

Error 3: Missing tests