### PR TITLE
Update grains.wat - typo in "total" description

### DIFF
--- a/exercises/practice/grains/grains.wat
+++ b/exercises/practice/grains/grains.wat
@@ -13,7 +13,7 @@
   )
 
   ;;
-  ;; Calculate the sum of grains of wheat acrosss all squares of the chessboard
+  ;; Calculate the sum of grains of wheat across all squares of the chessboard
   ;;
   ;; @returns {i64} - The number of grains of wheat on the entire chessboard.
   ;;                  The result is unsigned.


### PR DESCRIPTION
In the comments for the second function, the word "across" had an extra 's' at the end. Searched other files in exercise and didn't see any similar problem, just this file.