### PR TITLE
fix: all-your-base read offset / len if rc is 0

### DIFF
--- a/exercises/practice/all-your-base/all-your-base.spec.js
+++ b/exercises/practice/all-your-base/all-your-base.spec.js
@@ -31,6 +31,10 @@ function convert(digits = [], inputBase, outputBase) {
     outputBase
   );
 
+  if (rc !== 0) {
+    return [[], rc];
+  }
+
   const outputBuffer = currentInstance.get_mem_as_i32(
     outputOffset,
     outputLength


### PR DESCRIPTION
Resolves an error reported in https://forum.exercism.org/t/error-in-all-your-base-tests/8493 where the offset and length parameters were read by the test runner when the error code indicated they were invalid.