### PR TITLE
Several problems misstate the range of memory offsets used for buffers

### DIFF
--- a/exercises/practice/acronym/.docs/instructions.append.md
+++ b/exercises/practice/acronym/.docs/instructions.append.md
@@ -2,6 +2,6 @@
 
 ## Reserved Addresses
 
-The buffer for the input string uses bytes 64-196 of linear memory.
+The buffer for the input string uses bytes 64-191 of linear memory.
 
 You may modify this buffer in place if you wish to avoid additional memory allocations.

--- a/exercises/practice/hamming/.docs/instructions.append.md
+++ b/exercises/practice/hamming/.docs/instructions.append.md
@@ -3,6 +3,6 @@
 ## Reserved Addresses
 
 The buffer for the first string uses bytes 1024-2047 of linear memory.
-The buffer for the second string uses bytes 2048-3075 of linear memory.
+The buffer for the second string uses bytes 2048-3071 of linear memory.
 
 You should not have to modify these buffers or allocate additional memory.

--- a/exercises/practice/resistor-color/.docs/instructions.append.md
+++ b/exercises/practice/resistor-color/.docs/instructions.append.md
@@ -2,7 +2,7 @@
 
 ## Reserved Memory
 
-The buffer for the input string uses bytes 64-189 of linear memory.
+The buffer for the input string uses bytes 64-191 of linear memory.
 
 ## Arrays
 

--- a/exercises/practice/rna-transcription/.docs/instructions.append.md
+++ b/exercises/practice/rna-transcription/.docs/instructions.append.md
@@ -2,6 +2,6 @@
 
 ## Reserved Memory
 
-The buffer for the input string uses bytes 64-189 of linear memory.
+The buffer for the input string uses bytes 64-191 of linear memory.
 
 The input string can be modified in place if desired.

--- a/exercises/practice/two-fer/.docs/instructions.append.md
+++ b/exercises/practice/two-fer/.docs/instructions.append.md
@@ -2,4 +2,4 @@
 
 ## Reserved Addresses
 
-The buffer for the input string uses bytes 64-192 of linear memory.
+The buffer for the input string uses bytes 64-191 of linear memory.


### PR DESCRIPTION
Several problems use a range of memory offsets for a buffer.  The problem descriptions for some of these give an incorrect upper bound.  This change fixes them.  It was discussed in the forum in https://forum.exercism.org/t/minor-mistake-in-acronym-description/8492.
